### PR TITLE
Fix: Prevent comment reflow inside @examples blocks

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -227,9 +227,9 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
             continue;
         }
 
-        // Handle Roxygen tags
-        if (line.startsWith('@') && !line.startsWith('@@')) {
-            const currentTag = line.split(/\s+/)[0]; // Get the tag part (e.g., @param, @return)
+        // Handle Roxygen tags consistently with trimmedLine
+        if (trimmedLine.startsWith('@') && !trimmedLine.startsWith('@@')) {
+            const currentTag = trimmedLine.split(/\s+/)[0]; // Get the tag part (e.g., @param, @return)
             
             if (currentParagraph.length > 0) {
                 result += formatParagraph(currentParagraph, block, actualMaxWidth, inList, isRoxygenTag) + '\n';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -199,10 +199,13 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
             continue;
         }
 
-        // Check for Roxygen tags to toggle the inExamples state
-        if (trimmedLine.startsWith('@') && !trimmedLine.startsWith('@@')) {
-            const currentTag = trimmedLine.split(/\s+/)[0];
-            // Enter examples block if the tag is @examples or @examplesIf
+        // Pre-calculate Roxygen tag information for the current line
+        const isNewTag = trimmedLine.startsWith('@') && !trimmedLine.startsWith('@@');
+        let currentTag = '';
+        
+        if (isNewTag) {
+            currentTag = trimmedLine.split(/\s+/)[0];
+            // Toggle examples state if a new tag is encountered
             inExamples = (currentTag === '@examples' || currentTag === '@examplesIf');
         }
 
@@ -214,8 +217,7 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
             }
             
             // Retain the formatting logic for spacing out new tags
-            if (trimmedLine.startsWith('@') && !trimmedLine.startsWith('@@')) {
-                const currentTag = trimmedLine.split(/\s+/)[0];
+            if (isNewTag) {
                 if (isRoxygenTag && lastRoxygenTag && currentTag !== lastRoxygenTag) {
                     result += (block.originalIndentation + block.prefix).trimEnd() + '\n';
                 }
@@ -227,10 +229,8 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
             continue;
         }
 
-        // Handle Roxygen tags consistently with trimmedLine
-        if (trimmedLine.startsWith('@') && !trimmedLine.startsWith('@@')) {
-            const currentTag = trimmedLine.split(/\s+/)[0]; // Get the tag part (e.g., @param, @return)
-            
+        // Handle Roxygen tags consistently
+        if (isNewTag) {
             if (currentParagraph.length > 0) {
                 result += formatParagraph(currentParagraph, block, actualMaxWidth, inList, isRoxygenTag) + '\n';
                 currentParagraph = [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -176,9 +176,11 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
                     content = content.substring(openerMatch[0].length);
                 }
             } else {
-                const starMatch = content.match(/^(\s*)(\*+\s*)/);
+                const starMatch = content.match(/^(\s*)\*+\s?(.*)$/);
                 if (starMatch) {
-                    content = content.substring(starMatch[0].length);
+                    // Remove leading '*' and at most one separator space,
+                    // while preserving additional indentation as content.
+                    content = starMatch[2];
                 } else {
                     content = content.trimStart();
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,10 +129,11 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
     let isCStyleBlock = false;
     let cStyleOpener = '/*';
 
-    // Pre-scan for a standalone closer to detect partial block selections
-    const hasStandaloneCStyleCloser = (() => {
+    // Pre-scan for a leading C-style closer to detect partial block selections
+    // (covers both standalone `*/` and `*/ ...` on the same line)
+    const hasLeadingCStyleCloser = (() => {
         for (let j = startLine; j <= endLine; j++) {
-            if (/^\s*\*\/\s*$/.test(document.lineAt(j).text)) {
+            if (/^\s*\*\/(?:\s*\S.*)?$/.test(document.lineAt(j).text)) {
                 return true;
             }
         }
@@ -157,7 +158,7 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
             prefix = match[2];
             isCStyleBlock = prefix.includes('/*');
 
-            if (!isCStyleBlock && hasStandaloneCStyleCloser) {
+            if (!isCStyleBlock && hasLeadingCStyleCloser) {
                 // Likely started inside a C-style block whose opener is outside this range.
                 // Bail out to avoid corrupting the closer/opener structure.
                 return null;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,8 @@ interface CommentBlock {
     content: string[];
     /** The whitespace occurring before the comment prefix */
     originalIndentation: string;
+    isCStyleBlock?: boolean;
+    cStyleOpener?: string;
 }
 
 /**
@@ -81,8 +83,14 @@ function reflowComment(editor: vscode.TextEditor) {
         return;
     }
 
-    const reflowedText = reflowCommentBlock(commentBlock, wordWrapColumn);
+    let reflowedText = reflowCommentBlock(commentBlock, wordWrapColumn);
     
+    if (commentBlock.isCStyleBlock) {
+        const opener = `${commentBlock.originalIndentation}${commentBlock.cStyleOpener}\n`;
+        const closer = `\n${commentBlock.originalIndentation} */`;
+        reflowedText = opener + reflowedText + closer;
+    }
+
     editor.edit(editBuilder => {
         const range = new vscode.Range(
             new vscode.Position(startLine, 0),
@@ -118,38 +126,55 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
     let prefix = '';
     let originalIndentation = '';
     let isRoxygen = false;
+    let isCStyleBlock = false;
+    let cStyleOpener = '/*';
 
     for (let i = startLine; i <= endLine; i++) {
         const line = document.lineAt(i);
         const text = line.text;
 
         if (i === startLine) {
-            // Detect if this is a Roxygen comment block
             isRoxygen = text.trim().startsWith("#'");
-            // Detect the comment prefix and indentation from the first line
-            // Matches block comment opens (/* or /**), Roxygen (#' ), hashes (# ), slashes (// ), or asterisks (* )
             const match = text.match(/^(\s*)(\/\*+\s*|#'\s*|#+\s*|\/\/\s*|\*+\s+)/);
-            if (!match) {
-                return null;
-            }
+            if (!match) return null;
+            
             originalIndentation = match[1];
             prefix = match[2];
-
-            // Bail out for C-style block comments as they require dedicated multiline handling
-            if (prefix.includes('/*')) {
-                return null;
+            isCStyleBlock = prefix.includes('/*');
+            
+            if (isCStyleBlock) {
+                cStyleOpener = prefix.trim(); // Capture whether it's /* or /**
+                prefix = ' * '; // Standardize the prefix for the middle lines
             }
         }
 
-        // Bail out only on an actual standalone block-comment closer
-        if (/^\s*\*\/\s*$/.test(text)) {
-            return null;
-        }
-
-        // Remove the prefix and any leading/trailing whitespace
         let content = text;
-        if (isRoxygen) {
-            // Match the prefix (#' plus up to one space) and capture the rest
+        
+        if (isCStyleBlock) {
+            // Skip standalone closing lines (we'll re-add the closer later)
+            if (/^\s*\*\/\s*$/.test(text)) {
+                continue; 
+            }
+            
+            // Strip the closer if it's on the same line as text
+            content = content.replace(/\*\/\s*$/, '');
+            
+            // Strip the opener on the first line, or the leading * on subsequent lines
+            if (i === startLine) {
+                 const openerMatch = content.match(/^(\s*)(\/\*+\s*)/);
+                 if (openerMatch) {
+                     content = content.substring(openerMatch[0].length);
+                 }
+            } else {
+                 const starMatch = content.match(/^(\s*)(\*+\s*)/);
+                 if (starMatch) {
+                     content = content.substring(starMatch[0].length);
+                 } else {
+                     content = content.trimStart();
+                 }
+            }
+            content = content.trimEnd();
+        } else if (isRoxygen) {
             const roxyMatch = text.match(/^\s*#'\s?(.*)/);
             if (roxyMatch) {
                 content = roxyMatch[1].trimEnd();
@@ -158,13 +183,18 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
             content = text.substring(text.indexOf(prefix) + prefix.length).trim();
         }
         
+        // Skip adding the first line if it was just the opening `/**` with no text
+        if (isCStyleBlock && i === startLine && content === '') continue;
+        
         lines.push(content);
     }
 
     return {
-        prefix: isRoxygen ? "#' " : prefix,
+        prefix: isRoxygen ? "#' " : (isCStyleBlock ? " * " : prefix),
         content: lines,
-        originalIndentation
+        originalIndentation,
+        isCStyleBlock,
+        cStyleOpener
     };
 }
 
@@ -180,6 +210,7 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
     let inList = false;
     let isRoxygenTag = false;
     let lastRoxygenTag = '';
+    let macroDepth = 0;
 
     // Process each line
     for (const line of block.content) {
@@ -215,13 +246,35 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
             continue;
         }
 
+        // Track macro depth to prevent reflowing structural braces
+        const previousMacroDepth = macroDepth;
+        const braces = line.match(/\{|\}/g);
+        if (braces) {
+            for (const brace of braces) {
+                if (brace === '{') macroDepth++;
+                else if (brace === '}') macroDepth--;
+            }
+        }
+        if (macroDepth < 0) macroDepth = 0;
+
+        // If currently inside a macro block, append directly without reflowing
+        if (previousMacroDepth > 0 || macroDepth > 0) {
+            if (currentParagraph.length > 0) {
+                result += formatParagraph(currentParagraph, block, actualMaxWidth, inList, isRoxygenTag) + '\n';
+                currentParagraph = [];
+            }
+            result += (block.originalIndentation + block.prefix + line).trimEnd() + '\n';
+            continue;
+        }
+
         // Pre-calculate Roxygen tag information for the current line
-        const isNewTag = trimmedLine.startsWith('@') && !trimmedLine.startsWith('@@');
+        const isRoxygenBlock = block.prefix.startsWith("#'");
+        const isNewTag = isRoxygenBlock && trimmedLine.startsWith('@') && !trimmedLine.startsWith('@@');
         const isUnindentedTag = line.startsWith('@');
         const isStructuralTag = isNewTag && isUnindentedTag;
         let currentTag = '';
         
-        if (isNewTag) {
+        if (isStructuralTag) {
             currentTag = trimmedLine.split(/\s+/)[0];
             // Toggle examples state if a new tag is encountered
             if (!inExamples || isUnindentedTag) {
@@ -250,7 +303,7 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
         }
 
         // Handle Roxygen tags consistently
-        if (isNewTag) {
+        if (isStructuralTag) {
             if (currentParagraph.length > 0) {
                 result += formatParagraph(currentParagraph, block, actualMaxWidth, inList, isRoxygenTag) + '\n';
                 currentParagraph = [];
@@ -268,7 +321,9 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
         }
 
         // Handle bullet points and numbered lists
-        if (line.match(/^\s*([-*]|\d+\.)\s/)) {
+        const isListItem = line.match(/^\s*([-*]|\d+\.)\s/);
+        
+        if (isListItem) {
             if (!inList && currentParagraph.length > 0) {
                 result += formatParagraph(currentParagraph, block, actualMaxWidth, false, isRoxygenTag) + '\n';
                 currentParagraph = [];
@@ -280,6 +335,15 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
             }
             currentParagraph.push(line);
             continue;
+        } else if (inList) {
+            // Reset list state if we encounter a completely unindented line
+            if (line.length > 0 && !line.match(/^\s+/)) {
+                if (currentParagraph.length > 0) {
+                    result += formatParagraph(currentParagraph, block, actualMaxWidth, true, isRoxygenTag) + '\n';
+                    currentParagraph = [];
+                }
+                inList = false;
+            }
         }
 
         currentParagraph.push(line);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,9 +121,6 @@ function isCommentLine(line: string, languageId: string): boolean {
 /**
  * Extracts the comment block from the document
  */
-/**
- * Extracts the comment block from the document
- */
 function extractCommentBlock(document: vscode.TextDocument, startLine: number, endLine: number): CommentBlock | null {
     const lines = [];
     let prefix = '';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -285,12 +285,10 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
  * Formats a paragraph to fit within the specified width
  */
 function formatParagraph(paragraph: string[], block: CommentBlock, maxWidth: number, isList: boolean, isRoxygenTag: boolean): string {
-    // For Roxygen tags, preserve the tag at the start
     let prefix = '';
+    let listIndent = '';
     let words: string[] = [];
 
-    words = paragraph.join(' ').split(/\s+/).filter(w => w.length > 0);
-    
     if (isRoxygenTag) {
         // Extract the tag part (e.g., "@param name") and the description
         const firstLine = paragraph[0];
@@ -298,26 +296,37 @@ function formatParagraph(paragraph: string[], block: CommentBlock, maxWidth: num
         
         if (tagMatch) {
             prefix = tagMatch[1];
-            
             // Remove the tag part from the first line and combine with rest
-            const remainingText = firstLine.substring(prefix.length) + ' ' + 
-                                paragraph.slice(1).join(' ');
+            const remainingText = firstLine.substring(prefix.length) + ' ' + paragraph.slice(1).join(' ');
             words = remainingText.split(/\s+/).filter(w => w.length > 0);
+        } else {
+            words = paragraph.join(' ').split(/\s+/).filter(w => w.length > 0);
         }
-    }
-
-    // Calculate hanging indent for lists based on the bullet/number length
-    let listIndent = '';
-    if (isList && paragraph.length > 0) {
-        const listMatch = paragraph[0].match(/^\s*([-*]|\d+\.)\s+/);
+    } else if (isList && paragraph.length > 0) {
+        const firstLine = paragraph[0];
+        // Match leading space, the marker, and trailing spaces
+        const listMatch = firstLine.match(/^(\s*)([-*]|\d+\.)\s+/);
+        
         if (listMatch) {
-            // Normalize continuation indent to marker width + one space
-            listIndent = ' '.repeat(listMatch[1].length + 1);
+            const leadingSpace = listMatch[1];
+            const marker = listMatch[2];
+            prefix = leadingSpace + marker;
+            
+            // Calculate hanging indent: leading spaces + marker length + 1 space
+            listIndent = ' '.repeat(leadingSpace.length + marker.length + 1);
+            
+            // Extract words from the text after the list marker
+            const remainingText = firstLine.substring(listMatch[0].length) + ' ' + paragraph.slice(1).join(' ');
+            words = remainingText.split(/\s+/).filter(w => w.length > 0);
+        } else {
+            words = paragraph.join(' ').split(/\s+/).filter(w => w.length > 0);
         }
+    } else {
+        words = paragraph.join(' ').split(/\s+/).filter(w => w.length > 0);
     }
 
     const lines: string[] = [];
-    let currentLine = prefix; // Start with the Roxygen tag if present
+    let currentLine = prefix; // Start with the prefix (Roxygen tag or list marker)
 
     for (const word of words) {
         // If the current line + word + space (if line is not empty) is less

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -251,8 +251,8 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
             continue;
         }
 
-        // Handle bullet points
-        if (line.match(/^\s*[-*]\s/)) {
+        // Handle bullet points and numbered lists
+        if (line.match(/^\s*([-*]|\d+\.)\s/)) {
             if (!inList && currentParagraph.length > 0) {
                 result += formatParagraph(currentParagraph, block, actualMaxWidth, false, isRoxygenTag) + '\n';
                 currentParagraph = [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,14 +160,17 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
     let result = '';
     let currentParagraph: string[] = [];
     let inCodeBlock = false;
+    let inExamples = false;
     let inList = false;
     let isRoxygenTag = false;
     let lastRoxygenTag = '';
 
     // Process each line
     for (const line of block.content) {
+        const trimmedLine = line.trim();
+
         // Handle empty lines - they separate paragraphs
-        if (line.trim().length === 0) {
+        if (trimmedLine.length === 0) {
             if (currentParagraph.length > 0) {
                 result += formatParagraph(currentParagraph, block, actualMaxWidth, inList, isRoxygenTag) + '\n';
                 currentParagraph = [];
@@ -180,7 +183,7 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
         }
 
         // Handle code blocks (marked with ```)
-        if (line.trim().startsWith('```')) {
+        if (trimmedLine.startsWith('```')) {
             if (currentParagraph.length > 0) {
                 result += formatParagraph(currentParagraph, block, actualMaxWidth, inList, isRoxygenTag) + '\n';
                 currentParagraph = [];
@@ -192,6 +195,34 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
 
         // Don't reflow code blocks
         if (inCodeBlock) {
+            result += (block.originalIndentation + block.prefix + line).trimEnd() + '\n';
+            continue;
+        }
+
+        // Check for Roxygen tags to toggle the inExamples state
+        if (trimmedLine.startsWith('@') && !trimmedLine.startsWith('@@')) {
+            const currentTag = trimmedLine.split(/\s+/)[0];
+            // Enter examples block if the tag is @examples or @examplesIf
+            inExamples = (currentTag === '@examples' || currentTag === '@examplesIf');
+        }
+
+        // Don't reflow examples block
+        if (inExamples) {
+            if (currentParagraph.length > 0) {
+                result += formatParagraph(currentParagraph, block, actualMaxWidth, inList, isRoxygenTag) + '\n';
+                currentParagraph = [];
+            }
+            
+            // Retain the formatting logic for spacing out new tags
+            if (trimmedLine.startsWith('@') && !trimmedLine.startsWith('@@')) {
+                const currentTag = trimmedLine.split(/\s+/)[0];
+                if (isRoxygenTag && lastRoxygenTag && currentTag !== lastRoxygenTag) {
+                    result += (block.originalIndentation + block.prefix).trimEnd() + '\n';
+                }
+                isRoxygenTag = true;
+                lastRoxygenTag = currentTag;
+            }
+
             result += (block.originalIndentation + block.prefix + line).trimEnd() + '\n';
             continue;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -246,27 +246,6 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
             continue;
         }
 
-        // Track macro depth to prevent reflowing structural braces
-        const previousMacroDepth = macroDepth;
-        const braces = line.match(/\{|\}/g);
-        if (braces) {
-            for (const brace of braces) {
-                if (brace === '{') macroDepth++;
-                else if (brace === '}') macroDepth--;
-            }
-        }
-        if (macroDepth < 0) macroDepth = 0;
-
-        // If currently inside a macro block, append directly without reflowing
-        if (previousMacroDepth > 0 || macroDepth > 0) {
-            if (currentParagraph.length > 0) {
-                result += formatParagraph(currentParagraph, block, actualMaxWidth, inList, isRoxygenTag) + '\n';
-                currentParagraph = [];
-            }
-            result += (block.originalIndentation + block.prefix + line).trimEnd() + '\n';
-            continue;
-        }
-
         // Pre-calculate Roxygen tag information for the current line
         const isRoxygenBlock = block.prefix.startsWith("#'");
         const isNewTag = isRoxygenBlock && trimmedLine.startsWith('@') && !trimmedLine.startsWith('@@');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,19 @@
 import * as vscode from 'vscode';
 
-// Create output channel for logging
+/**
+ * Output channel for logging extension events
+ */
 let outputChannel: vscode.OutputChannel;
 
 /**
  * Represents a comment block with its prefix and content
  */
 interface CommentBlock {
+    /** The comment character or prefix used */
     prefix: string;
+    /** The text content of the comment block */
     content: string[];
+    /** The whitespace occurring before the comment prefix */
     originalIndentation: string;
 }
 
@@ -348,4 +353,7 @@ function formatParagraph(paragraph: string[], block: CommentBlock, maxWidth: num
         .join('\n');
 }
 
+/**
+ * Deactivates the extension
+ */
 export function deactivate() {} 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,17 +127,29 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
             // Detect if this is a Roxygen comment block
             isRoxygen = text.trim().startsWith("#'");
             // Detect the comment prefix and indentation from the first line
+            // Matches block comment opens (/* or /**), Roxygen (#' ), hashes (# ), slashes (// ), or asterisks (* )
             const match = text.match(/^(\s*)(\/\*+\s*|#'\s*|#+\s*|\/\/\s*|\*+\s+)/);
             if (!match) {
                 return null;
             }
             originalIndentation = match[1];
             prefix = match[2];
+
+            // Bail out for C-style block comments as they require dedicated multiline handling
+            if (prefix.includes('/*')) {
+                return null;
+            }
+        }
+
+        // Bail out if we hit a closing block comment marker anywhere
+        if (text.includes('*/')) {
+            return null;
         }
 
         // Remove the prefix and any leading/trailing whitespace
         let content = text;
         if (isRoxygen) {
+            // Match the prefix (#' plus up to one space) and capture the rest
             const roxyMatch = text.match(/^\s*#'\s?(.*)/);
             if (roxyMatch) {
                 content = roxyMatch[1].trimEnd();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,7 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
             // Detect if this is a Roxygen comment block
             isRoxygen = text.trim().startsWith("#'");
             // Detect the comment prefix and indentation from the first line
-            const match = text.match(/^(\s*)(#'\s*|#+\s*|\/\/\s*|\*\s+)/);
+            const match = text.match(/^(\s*)(\/\*+\s*|#'\s*|#+\s*|\/\/\s*|\*+\s+)/);
             if (!match) {
                 return null;
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,9 +134,9 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
         // Remove the prefix and any leading/trailing whitespace
         let content = text;
         if (isRoxygen) {
-            const roxyMatch = text.match(/^(\s*#'\s*)(.*)/);
+            const roxyMatch = text.match(/^\s*#'\s?(.*)/);
             if (roxyMatch) {
-                content = roxyMatch[2];
+                content = roxyMatch[1].trimEnd();
             }
         } else {
             content = text.substring(text.indexOf(prefix) + prefix.length).trim();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,6 +129,16 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
     let isCStyleBlock = false;
     let cStyleOpener = '/*';
 
+    // Pre-scan for a standalone closer to detect partial block selections
+    const hasStandaloneCStyleCloser = (() => {
+        for (let j = startLine; j <= endLine; j++) {
+            if (/^\s*\*\/\s*$/.test(document.lineAt(j).text)) {
+                return true;
+            }
+        }
+        return false;
+    })();
+
     for (let i = startLine; i <= endLine; i++) {
         const line = document.lineAt(i);
         const text = line.text;
@@ -146,6 +156,12 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
             originalIndentation = match[1];
             prefix = match[2];
             isCStyleBlock = prefix.includes('/*');
+
+            if (!isCStyleBlock && hasStandaloneCStyleCloser) {
+                // Likely started inside a C-style block whose opener is outside this range.
+                // Bail out to avoid corrupting the closer/opener structure.
+                return null;
+            }
             
             if (isCStyleBlock) {
                 cStyleOpener = prefix.trim(); // Capture whether it's /* or /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -201,12 +201,15 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
 
         // Pre-calculate Roxygen tag information for the current line
         const isNewTag = trimmedLine.startsWith('@') && !trimmedLine.startsWith('@@');
+        const isUnindentedTag = line.startsWith('@');
         let currentTag = '';
         
         if (isNewTag) {
             currentTag = trimmedLine.split(/\s+/)[0];
             // Toggle examples state if a new tag is encountered
-            inExamples = (currentTag === '@examples' || currentTag === '@examplesIf');
+            if (!inExamples || isUnindentedTag) {
+                inExamples = (currentTag === '@examples' || currentTag === '@examplesIf');
+            }
         }
 
         // Don't reflow examples block

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -262,7 +262,7 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
                 result += formatParagraph(currentParagraph, block, actualMaxWidth, true, isRoxygenTag) + '\n';
                 currentParagraph = [];
             }
-            result += (block.originalIndentation + block.prefix + line).trimEnd() + '\n';
+            currentParagraph.push(line);
             continue;
         }
 
@@ -302,6 +302,15 @@ function formatParagraph(paragraph: string[], block: CommentBlock, maxWidth: num
         }
     }
 
+    // Calculate hanging indent for lists based on the bullet/number length
+    let listIndent = '';
+    if (isList && paragraph.length > 0) {
+        const listMatch = paragraph[0].match(/^(\s*([-*]|\d+\.)\s+)/);
+        if (listMatch) {
+            listIndent = ' '.repeat(listMatch[1].length);
+        }
+    }
+
     const lines: string[] = [];
     let currentLine = prefix; // Start with the Roxygen tag if present
 
@@ -316,9 +325,14 @@ function formatParagraph(paragraph: string[], block: CommentBlock, maxWidth: num
             if (currentLine.length > 0) {
                 lines.push(currentLine);
             }
-            // For continuation lines in Roxygen tags, add appropriate
-            // indentation
-            currentLine = isRoxygenTag && lines.length > 0 ? '  ' + word : word;
+            // For continuation lines, add appropriate indentation
+            if (isRoxygenTag && lines.length > 0) {
+                currentLine = '  ' + word;
+            } else if (isList && lines.length > 0) {
+                currentLine = listIndent + word;
+            } else {
+                currentLine = word;
+            }
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -305,9 +305,13 @@ function formatParagraph(paragraph: string[], block: CommentBlock, maxWidth: num
     // Calculate hanging indent for lists based on the bullet/number length
     let listIndent = '';
     if (isList && paragraph.length > 0) {
-        const listMatch = paragraph[0].match(/^(\s*([-*]|\d+\.)\s+)/);
+        const listMatch = paragraph[0].match(/^\s*([-*]|\d+\.)\s+/);
         if (listMatch) {
-            listIndent = ' '.repeat(listMatch[1].length);
+            // Calculate indent from marker + space only, excluding leading whitespace
+            const markerMatch = listMatch[0].match(/([-*]|\d+\.)\s+/);
+            if (markerMatch) {
+                listIndent = ' '.repeat(markerMatch[0].length);
+            }
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,6 +121,9 @@ function isCommentLine(line: string, languageId: string): boolean {
 /**
  * Extracts the comment block from the document
  */
+/**
+ * Extracts the comment block from the document
+ */
 function extractCommentBlock(document: vscode.TextDocument, startLine: number, endLine: number): CommentBlock | null {
     const lines = [];
     let prefix = '';
@@ -134,9 +137,14 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
         const text = line.text;
 
         if (i === startLine) {
+            // Detect if this is a Roxygen comment block
             isRoxygen = text.trim().startsWith("#'");
+            
+            // Detect the comment prefix and indentation from the first line
             const match = text.match(/^(\s*)(\/\*+\s*|#'\s*|#+\s*|\/\/\s*|\*+\s+)/);
-            if (!match) return null;
+            if (!match) {
+                return null;
+            }
             
             originalIndentation = match[1];
             prefix = match[2];
@@ -151,6 +159,11 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
         let content = text;
         
         if (isCStyleBlock) {
+            // Avoid rewriting inline block comments that have code/text after the closer.
+            if (/\*\/\s*\S/.test(text)) {
+                return null;
+            }
+
             // Skip standalone closing lines (we'll re-add the closer later)
             if (/^\s*\*\/\s*$/.test(text)) {
                 continue; 
@@ -161,20 +174,21 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
             
             // Strip the opener on the first line, or the leading * on subsequent lines
             if (i === startLine) {
-                 const openerMatch = content.match(/^(\s*)(\/\*+\s*)/);
-                 if (openerMatch) {
-                     content = content.substring(openerMatch[0].length);
-                 }
+                const openerMatch = content.match(/^(\s*)(\/\*+\s*)/);
+                if (openerMatch) {
+                    content = content.substring(openerMatch[0].length);
+                }
             } else {
-                 const starMatch = content.match(/^(\s*)(\*+\s*)/);
-                 if (starMatch) {
-                     content = content.substring(starMatch[0].length);
-                 } else {
-                     content = content.trimStart();
-                 }
+                const starMatch = content.match(/^(\s*)(\*+\s*)/);
+                if (starMatch) {
+                    content = content.substring(starMatch[0].length);
+                } else {
+                    content = content.trimStart();
+                }
             }
             content = content.trimEnd();
         } else if (isRoxygen) {
+            // Match the prefix (#' plus up to one space) and capture the rest
             const roxyMatch = text.match(/^\s*#'\s?(.*)/);
             if (roxyMatch) {
                 content = roxyMatch[1].trimEnd();
@@ -184,7 +198,9 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
         }
         
         // Skip adding the first line if it was just the opening `/**` with no text
-        if (isCStyleBlock && i === startLine && content === '') continue;
+        if (isCStyleBlock && i === startLine && content === '') {
+            continue;
+        }
         
         lines.push(content);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,6 +202,7 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
         // Pre-calculate Roxygen tag information for the current line
         const isNewTag = trimmedLine.startsWith('@') && !trimmedLine.startsWith('@@');
         const isUnindentedTag = line.startsWith('@');
+        const isStructuralTag = isNewTag && isUnindentedTag;
         let currentTag = '';
         
         if (isNewTag) {
@@ -220,7 +221,7 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
             }
             
             // Retain the formatting logic for spacing out new tags
-            if (isNewTag) {
+            if (isStructuralTag) {
                 if (isRoxygenTag && lastRoxygenTag && currentTag !== lastRoxygenTag) {
                     result += (block.originalIndentation + block.prefix).trimEnd() + '\n';
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -282,6 +282,29 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
             }
         }
 
+        // Track macro depth only when not inside `@examples`
+        if (!inExamples) {
+            const previousMacroDepth = macroDepth;
+            const braces = line.match(/\{|\}/g);
+            if (braces) {
+                for (const brace of braces) {
+                    if (brace === '{') macroDepth++;
+                    else if (brace === '}') macroDepth--;
+                }
+            }
+            if (macroDepth < 0) macroDepth = 0;
+
+            // If currently inside a macro block, append directly without reflowing
+            if (previousMacroDepth > 0 || macroDepth > 0) {
+                if (currentParagraph.length > 0) {
+                    result += formatParagraph(currentParagraph, block, actualMaxWidth, inList, isRoxygenTag) + '\n';
+                    currentParagraph = [];
+                }
+                result += (block.originalIndentation + block.prefix + line).trimEnd() + '\n';
+                continue;
+            }
+        }
+
         // Don't reflow examples block
         if (inExamples) {
             if (currentParagraph.length > 0) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -247,7 +247,7 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
 
             isRoxygenTag = true;
             lastRoxygenTag = currentTag;
-            currentParagraph.push(line);
+            currentParagraph.push(trimmedLine);
             continue;
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -307,11 +307,8 @@ function formatParagraph(paragraph: string[], block: CommentBlock, maxWidth: num
     if (isList && paragraph.length > 0) {
         const listMatch = paragraph[0].match(/^\s*([-*]|\d+\.)\s+/);
         if (listMatch) {
-            // Calculate indent from marker + space only, excluding leading whitespace
-            const markerMatch = listMatch[0].match(/([-*]|\d+\.)\s+/);
-            if (markerMatch) {
-                listIndent = ' '.repeat(markerMatch[0].length);
-            }
+            // Normalize continuation indent to marker width + one space
+            listIndent = ' '.repeat(listMatch[1].length + 1);
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,6 @@ interface CommentBlock {
 export function activate(context: vscode.ExtensionContext) {
     // Initialize output channel
     outputChannel = vscode.window.createOutputChannel('RStudio Comment Reflow');
-    outputChannel.show();
     
     outputChannel.appendLine('RStudio Comment Reflow extension is now active');
     outputChannel.appendLine(`OS: ${process.platform}`);
@@ -128,7 +127,7 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
             // Detect if this is a Roxygen comment block
             isRoxygen = text.trim().startsWith("#'");
             // Detect the comment prefix and indentation from the first line
-            const match = text.match(/^(\s*)([#']+\s*|\*\s+)/);
+            const match = text.match(/^(\s*)(#'\s*|#+\s*|\/\/\s*|\*\s+)/);
             if (!match) {
                 return null;
             }
@@ -356,4 +355,8 @@ function formatParagraph(paragraph: string[], block: CommentBlock, maxWidth: num
 /**
  * Deactivates the extension
  */
-export function deactivate() {} 
+export function deactivate() {
+    if (outputChannel) {
+        outputChannel.dispose();
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,8 +141,8 @@ function extractCommentBlock(document: vscode.TextDocument, startLine: number, e
             }
         }
 
-        // Bail out if we hit a closing block comment marker anywhere
-        if (text.includes('*/')) {
+        // Bail out only on an actual standalone block-comment closer
+        if (/^\s*\*\/\s*$/.test(text)) {
             return null;
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -287,9 +287,7 @@ function reflowCommentBlock(block: CommentBlock, maxWidth: number): string {
         if (isStructuralTag) {
             currentTag = trimmedLine.split(/\s+/)[0];
             // Toggle examples state if a new tag is encountered
-            if (!inExamples || isUnindentedTag) {
-                inExamples = (currentTag === '@examples' || currentTag === '@examplesIf');
-            }
+            inExamples = (currentTag === '@examples' || currentTag === '@examplesIf');
         }
 
         // Track macro depth only when not inside `@examples`


### PR DESCRIPTION
Addresses https://github.com/bakaburg1/rstudio-comment-reflow/issues/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full C-style comment block support with preserved openers/closers, standardized middle-line prefixes, and per-line handling.
  * Enhanced parsing for Roxygen, examples, and code/macro contexts; improved list and hanging-indent formatting.

* **Bug Fixes**
  * Avoids unintended reflow and corruption by better tag-boundary detection and skipping problematic ranges; preserves indentation and wrappers.

* **Chores**
  * Output panel no longer opens automatically and is disposed on deactivation.

* **Documentation**
  * Updated inline docs describing comment-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->